### PR TITLE
Fix compilation warnings for Elixir 1.16

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/zxcvbn/scoring.ex
+++ b/lib/zxcvbn/scoring.ex
@@ -234,7 +234,7 @@ defmodule ZXCVBN.Scoring do
       char_class_base in @char_class_bases_names ->
         pow(@char_class_bases[char_class_base], strlen(token))
 
-      char_class_base === 'recent_year' ->
+      char_class_base === ~c"recent_year" ->
         # conservative estimate of year space: num years from `@reference_year`.
         # if year is close to `@reference_year`, estimate a year space of
         # `@min_year_space`

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ZXCVBN.MixProject do
     [
       app: :zxcvbn,
       version: "0.1.3",
-      elixir: "~> 1.7",
+      elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       build_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
`Config` was added in Elixir 1.9, which was released 5 years ago: https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/ so I've bumped the minimum version of Elixir to 1.9.

`sigil_c` was added pre-1.0