### PR TITLE
Update matching.ex

### DIFF
--- a/lib/zxcvbn/matching.ex
+++ b/lib/zxcvbn/matching.ex
@@ -634,7 +634,7 @@ defmodule ZXCVBN.Matching do
   defp date_no_separator_matches(password) do
     length = strlen(password)
 
-    for i <- 0..(length - 4), j <- (i + 3)..(i + 8), i >= 0, j < length do
+    for i <- Range.new(0, length - 4), j <- Range.new(i + 3, i + 8), i >= 0, j < length do
       token = slice(password, i..j)
       token_length = strlen(token)
 
@@ -683,7 +683,7 @@ defmodule ZXCVBN.Matching do
   defp date_with_separator_matches(password) do
     length = strlen(password)
 
-    for i <- 0..(length - 5), j <- (i + 5)..(i + 10), i >= 0, j < length do
+    for i <- Range.new(0, length - 5), j <- Range.new(i + 5, i + 10), i >= 0, j < length do
       token = slice(password, i..j)
 
       rx_match = Regex.run(@maybe_date_with_separator, token)


### PR DESCRIPTION
Address warnings:

```
warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:637: ZXCVBN.Matching.date_no_separator_matches/1
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:623: ZXCVBN.Matching.date_match/2
  (elixir 1.18.0) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.18.0) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:100: ZXCVBN.Matching.omnimatch/2
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:336: anonymous fn/5 in ZXCVBN.Matching.repeat_match/2
  (elixir 1.18.0) lib/range.ex:552: Enumerable.Range.reduce/5
  (elixir 1.18.0) lib/enum.ex:2600: Enum.reduce_while/3
  (elixir 1.18.0) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.18.0) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:100: ZXCVBN.Matching.omnimatch/2
  (zxcvbn 0.2.0) lib/zxcvbn.ex:92: ZXCVBN.zxcvbn/2
  (api 1.0.0) lib/myapp/controllers/password_strength_controller.ex:5: MyApp.PasswordStrengthController.password_strength/2
  (api 1.0.0) lib/myapp/controllers/password_strength_controller.ex:1: MyApp.PasswordStrengthController.action/2
  (api 1.0.0) lib/myapp/controllers/password_strength_controller.ex:1: MyApp.PasswordStrengthController.phoenix_controller_pipeline/2
  (phoenix 1.7.18) lib/phoenix/router.ex:484: Phoenix.Router.__call__/5
  (api 1.0.0) lib/myapp/endpoint.ex:1: MyApp.Endpoint.plug_builder_call/2

warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:686: ZXCVBN.Matching.date_with_separator_matches/1
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:624: ZXCVBN.Matching.date_match/2
  (elixir 1.18.0) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.18.0) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:100: ZXCVBN.Matching.omnimatch/2
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:336: anonymous fn/5 in ZXCVBN.Matching.repeat_match/2
  (elixir 1.18.0) lib/range.ex:552: Enumerable.Range.reduce/5
  (elixir 1.18.0) lib/enum.ex:2600: Enum.reduce_while/3
  (elixir 1.18.0) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.18.0) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (zxcvbn 0.2.0) lib/zxcvbn/matching.ex:100: ZXCVBN.Matching.omnimatch/2
  (zxcvbn 0.2.0) lib/zxcvbn.ex:92: ZXCVBN.zxcvbn/2
  (api 1.0.0) lib/myapp/controllers/password_strength_controller.ex:5: MyApp.PasswordStrengthController.password_strength/2
  (api 1.0.0) lib/myapp/controllers/password_strength_controller.ex:1: MyApp.PasswordStrengthController.action/2
  (api 1.0.0) lib/myapp/controllers/password_strength_controller.ex:1: MyApp.PasswordStrengthController.phoenix_controller_pipeline/2
  (phoenix 1.7.18) lib/phoenix/router.ex:484: Phoenix.Router.__call__/5
  (api 1.0.0) lib/myapp/endpoint.ex:1: ContractbookApi.Endpoint.plug_builder_call/2
```