### PR TITLE
Fix warnings surfacing in latest Elixir 1.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ```elixir
 def deps do
   [
-    {:zxcvbn, "~> 0.1.3"}
+    {:zxcvbn, "~> 0.2"}
   ]
 end
 ```

--- a/lib/zxcvbn/matching.ex
+++ b/lib/zxcvbn/matching.ex
@@ -634,7 +634,7 @@ defmodule ZXCVBN.Matching do
   defp date_no_separator_matches(password) do
     length = strlen(password)
 
-    for i <- Range.new(0, length - 4), j <- Range.new(i + 3, i + 8), i >= 0, j < length do
+    for i <- Range.new(0, length - 4, 1), j <- Range.new(i + 3, i + 8, 1), i >= 0, j < length do
       token = slice(password, i..j)
       token_length = strlen(token)
 
@@ -683,7 +683,7 @@ defmodule ZXCVBN.Matching do
   defp date_with_separator_matches(password) do
     length = strlen(password)
 
-    for i <- Range.new(0, length - 5), j <- Range.new(i + 5, i + 10), i >= 0, j < length do
+    for i <- Range.new(0, length - 5, 1), j <- Range.new(i + 5, i + 10, 1), i >= 0, j < length do
       token = slice(password, i..j)
 
       rx_match = Regex.run(@maybe_date_with_separator, token)

--- a/lib/zxcvbn/utils.ex
+++ b/lib/zxcvbn/utils.ex
@@ -33,7 +33,7 @@ defmodule ZXCVBN.Utils do
     end
   end
 
-  def slice(string, l..r) do
+  def slice(string, l..r//_) do
     slice(string, l, r - l + 1)
   end
 


### PR DESCRIPTION
We are seeing warnings when running `zxcvbn` in our application after upgrading to Elixir 1.18.1. Hopefully this is sufficient to keep the warnings happy.