### PR TITLE
Update to comply with Elixir 1.12+ Range changes

### DIFF
--- a/lib/zxcvbn/matching.ex
+++ b/lib/zxcvbn/matching.ex
@@ -634,7 +634,7 @@ defmodule ZXCVBN.Matching do
   defp date_no_separator_matches(password) do
     length = strlen(password)
 
-    for i <- Range.new(0, length - 4), j <- Range.new(i + 3, i + 8), i >= 0, j < length do
+    for i <- Range.new(0, length - 4, 1), j <- Range.new(i + 3, i + 8), i >= 0, j < length do
       token = slice(password, i..j)
       token_length = strlen(token)
 
@@ -683,7 +683,7 @@ defmodule ZXCVBN.Matching do
   defp date_with_separator_matches(password) do
     length = strlen(password)
 
-    for i <- Range.new(0, length - 5), j <- Range.new(i + 5, i + 10), i >= 0, j < length do
+    for i <- Range.new(0, length - 5, 1), j <- Range.new(i + 5, i + 10), i >= 0, j < length do
       token = slice(password, i..j)
 
       rx_match = Regex.run(@maybe_date_with_separator, token)

--- a/lib/zxcvbn/utils.ex
+++ b/lib/zxcvbn/utils.ex
@@ -20,20 +20,23 @@ defmodule ZXCVBN.Utils do
     |> Enum.reduce(0, fn
       i, len when i >= 0 and i <= 65535 ->
         len + 1
+
       _i, len ->
         len + 2
     end)
   end
+
   def strlen(string) do
     case mode() do
       :default ->
         String.length(string)
+
       _ ->
         byte_size(string)
     end
   end
 
-  def slice(string, l..r) do
+  def slice(string, l..r//_) do
     slice(string, l, r - l + 1)
   end
 
@@ -41,6 +44,7 @@ defmodule ZXCVBN.Utils do
     case mode() do
       :default ->
         String.slice(string, start_pos, len)
+
       _ ->
         binary_part(string, start_pos, len)
     end


### PR DESCRIPTION
At matching.ex 637 & 686 with short passwords "last" could become < "first" generating the warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  