### PR TITLE
Update the changelog to reflect the new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+- Updating the project's elixir/erlang versions for testing
+
 ## [0.2.0](https://github.com/techgaun/zxcvbn-elixir/compare/a147036eddcd26b37fc27e50b1194878d5c66d65...9b5bd8c8d5790b67f6aa33dc4ca84717e7cde558)
 
 - configurable text mode ([#18](https://github.com/techgaun/zxcvbn-elixir/pull/18))


### PR DESCRIPTION
I personally suggest you bump the latest version to 1.0.0, so that whenever you make a release like this again it can be a `patch` level change and not a `minor` bump.